### PR TITLE
fix: Remove garbage "hash-source" path from content

### DIFF
--- a/nix/packages/docs-site/default.nix
+++ b/nix/packages/docs-site/default.nix
@@ -19,8 +19,8 @@ buildNpmPackage {
   npmFlags = [ "--ignore-scripts" ];
 
   postUnpack = ''
-    mkdir -p $sourceRoot/src/content
-    cp -r ${inputs.wiki} $sourceRoot/src/content/wiki
+    mkdir -p $sourceRoot/src/content/wiki
+    cp -r ${inputs.wiki}/* $sourceRoot/src/content/wiki
   '';
 
   installPhase = ''


### PR DESCRIPTION
Previously, when this was used as a flake, the src/content/wiki directory was as empty folder. This meant that the nix script would move the content in, keeping the source folder name intact

By moving the content of the folder, we can mitigate this issue no matter whether the folder was pre-existing